### PR TITLE
remove the application label in the library

### DIFF
--- a/SwitchButton/library/src/main/AndroidManifest.xml
+++ b/SwitchButton/library/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 		  package="com.kyleduo.switchbutton">
 
 	<application android:allowBackup="true"
-				 android:label="@string/app_name"
 		>
 
 	</application>


### PR DESCRIPTION
It may cause errors like:
```
Error:Execution failed for task ':app:processOfflineDebugManifest'.
> Manifest merger failed : Attribute application@label value=(offline) from AndroidManifest.xml:42:9
  	is also present at com.kyleduo.switchbutton:library:1.2.9:13:9 value=(@string/app_name)
  	Suggestion: add 'tools:replace="android:label"' to <application> element at AndroidManifest.xml:37:5 to override
```