### PR TITLE
recomputing text margins in onMeasure to handle dynamic text changes

### DIFF
--- a/SwitchButton/library/src/main/java/com/kyleduo/switchbutton/SwitchButton.java
+++ b/SwitchButton/library/src/main/java/com/kyleduo/switchbutton/SwitchButton.java
@@ -263,6 +263,7 @@ public class SwitchButton extends CompoundButton {
 		if (mOffLayout == null && mTextOff != null) {
 			mOffLayout = makeLayout(mTextOff);
 		}
+      setupText();
 		setMeasuredDimension(measureWidth(widthMeasureSpec), measureHeight(heightMeasureSpec));
 	}
 
@@ -382,6 +383,13 @@ public class SwitchButton extends CompoundButton {
 			mBackDrawable.setBounds((int) mBackRectF.left, (int) mBackRectF.top, ceil(mBackRectF.right), ceil(mBackRectF.bottom));
 		}
 
+		setupText();
+	}
+
+	/**
+	 * Computes the margin of the text within the layout to center the text.
+	 */
+	protected void setupText() {
 		if (mOnLayout != null) {
 			float marginOnX = mBackRectF.left + (mBackRectF.width() - mThumbRectF.width() - mThumbMargin.right - mOnLayout.getWidth()) / 2 + (mThumbMargin.left < 0 ? mThumbMargin.left * -0.5f : 0);
 			if (!mIsBackUseDrawable && mAutoAdjustTextPosition) {


### PR DESCRIPTION
onSizeChanged() is called when a text longer than size of current layout is set and the margins are recomputed in setup(). The margins also need to be recomputed to center the text when the text is smaller or equal to the size of the current layout. 

issue:
https://github.com/kyleduo/SwitchButton/issues/65
